### PR TITLE
Make compatible with kitspace.org

### DIFF
--- a/kitspace.yaml
+++ b/kitspace.yaml
@@ -1,0 +1,3 @@
+gerbers: pcb/production/v0.1/gerber/
+bom: pcb/production/v0.1/bom.csv
+color: black


### PR DESCRIPTION
Hey, I thought this would be a nice project to add to https://kitspace.org. The idea of Kitspace is to make it as easy as possible to actually build people's open source hardware designs. 

All that's required to add your project is to merge this PR. It includes a kitspace.yaml manifest file that helps us find the right files. After you merge the Kitspace page will keep updating with your repo.

Here is [a preview](http://add-key-ripper.preview.kitspace.org/boards/github.com/kitspace-forks/key-ripper/) of what your project would look like. If you have any questions don't hesitate to ask. 


