### PR TITLE
allow for Fn key to be anywhere on keyboard

### DIFF
--- a/firmware/src/key_codes.rs
+++ b/firmware/src/key_codes.rs
@@ -2,7 +2,7 @@ use defmt::Format;
 
 #[allow(unused)]
 #[repr(u8)]
-#[derive(Copy, Clone, Format)]
+#[derive(Copy, Clone, Format, PartialEq)]
 pub enum KeyCode {
     Empty = 0x0,
     A = 0x04,
@@ -76,6 +76,12 @@ pub enum KeyCode {
     Down = 0x51,
     Up = 0x52,
 
+    Home = 0x4A,
+    PageUp = 0x4B,
+    Delete = 0x4C,
+    End = 0x4D,
+    PageDown = 0x4E,
+
     // Media Keys
     VolumeMute = 0x7F,
     VolumeUp = 0x80,
@@ -109,6 +115,6 @@ impl KeyCode {
     }
 
     pub fn is_modifier(&self) -> bool {
-        self.modifier_bitmask().is_some()
+        *self == KeyCode::Fn || self.modifier_bitmask().is_some()
     }
 }


### PR DESCRIPTION
I wanted to be able to do one-handed scrolling easily by making the key to the right of the spacebar (RightCmd by default) one of two Fn keys so that either hand could reach a Fn for one-handed coffee-drinking keyboarding.

Added some extra keycodes so I could do some new mappings in Fn state of my personal mappings file:
* arrows become Home, End, PageUp and PageDown
* Backspace becomes Delete
* 9 and 0 become () and [] becomes {} as if the Fn key was also a "shift" for them.