### PR TITLE
allow for Fn key to be anywhere on keyboard

### DIFF
--- a/firmware/src/key_codes.rs
+++ b/firmware/src/key_codes.rs
@@ -81,6 +81,10 @@ pub enum KeyCode {
     VolumeUp = 0x80,
     VolumeDown = 0x81,
 
+    // Keypad keys
+    LeftParen = 0xB6,
+    RightParen = 0xB7,
+
     // Modifier keys
     Fn = 0xF0,
     LeftShift = 0xF1,

--- a/firmware/src/key_codes.rs
+++ b/firmware/src/key_codes.rs
@@ -2,7 +2,7 @@ use defmt::Format;
 
 #[allow(unused)]
 #[repr(u8)]
-#[derive(Copy, Clone, Format)]
+#[derive(Copy, Clone, Format, PartialEq)]
 pub enum KeyCode {
     Empty = 0x0,
     A = 0x04,
@@ -76,6 +76,12 @@ pub enum KeyCode {
     Down = 0x51,
     Up = 0x52,
 
+    Home = 0x4A,
+    PageUp = 0x4B,
+    Delete = 0x4C,
+    End = 0x4D,
+    PageDown = 0x4E,
+
     // Media Keys
     VolumeMute = 0x7F,
     VolumeUp = 0x80,
@@ -113,6 +119,6 @@ impl KeyCode {
     }
 
     pub fn is_modifier(&self) -> bool {
-        self.modifier_bitmask().is_some()
+        *self == KeyCode::Fn || self.modifier_bitmask().is_some()
     }
 }

--- a/firmware/src/key_scan.rs
+++ b/firmware/src/key_scan.rs
@@ -4,7 +4,7 @@ use cortex_m::delay::Delay;
 use embedded_hal::digital::v2::InputPin;
 use usbd_hid::descriptor::KeyboardReport;
 
-use crate::{debounce::Debounce, key_mapping};
+use crate::{debounce::Debounce, key_codes::KeyCode, key_mapping};
 
 #[derive(Clone, Copy)]
 pub struct KeyScan<const NUM_ROWS: usize, const NUM_COLS: usize> {
@@ -60,12 +60,17 @@ impl<const NUM_ROWS: usize, const NUM_COLS: usize> From<KeyScan<NUM_ROWS, NUM_CO
             }
         };
 
-        let layer_mapping = if scan.matrix[0][5] {
-            key_mapping::FN_LAYER_MAPPING
-        } else {
-            key_mapping::NORMAL_LAYER_MAPPING
-        };
+        // First scan for any function keys being pressed
+        let mut layer_mapping = key_mapping::NORMAL_LAYER_MAPPING;
+        for (matrix_column, mapping_column) in scan.matrix.iter().zip(layer_mapping) {
+            for (key_pressed, mapping_row) in matrix_column.iter().zip(mapping_column) {
+                if mapping_row == KeyCode::Fn && *key_pressed {
+                    layer_mapping = key_mapping::FN_LAYER_MAPPING;
+                }
+            }
+        }
 
+        // Second scan to generate the correct keycodes given the activated key map
         for (matrix_column, mapping_column) in scan.matrix.iter().zip(layer_mapping) {
             for (key_pressed, mapping_row) in matrix_column.iter().zip(mapping_column) {
                 if *key_pressed {


### PR DESCRIPTION
Opening over #35 since branches got messed up.

I wanted to be able to do one-handed scrolling easily by making the key to the right of the spacebar (RightCmd by default) one of two Fn keys so that either hand could reach a Fn for one-handed coffee-drinking keyboarding.

Added some extra keycodes so I could do some new mappings in Fn state of my personal mappings file:
* arrows become Home, End, PageUp and PageDown
* Backspace becomes Delete
* 9 and 0 become () and [] becomes {} as if the Fn key was also a "shift" for them.