### PR TITLE
Implement the rest of the USB HID Class

### DIFF
--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -200,7 +200,7 @@ fn main() -> ! {
                     let mut hid_class = USB_HID_CLASS.borrow_ref_mut(cs);
                     let hid_class = hid_class.as_mut().unwrap();
 
-                    if let Err(err) = hid_class.write_raw_report(&report.as_raw_input()) {
+                    if let Err(err) = hid_class.write_raw_report(report.as_raw_input()) {
                         match err {
                             UsbError::WouldBlock => warn!("UsbError::WouldBlock"),
                             UsbError::ParseError => error!("UsbError::ParseError"),


### PR DESCRIPTION
From the [spec](https://www.usb.org/sites/default/files/hid1_11.pdf), Appendix C

## TODO

- [ ] The keyboard must support the Idle request.
- [ ] The keyboard must send data reports at the Idle rate or when receiving a Get_Report request, even when there are no new key events.
- [ ] The keyboard must report a phantom state indexing Usage(ErrorRollOver) in all array fields whenever the number of keys pressed exceeds the Report Count. The limit is six non-modifier keys when using the keyboard descriptor in Appendix B. Additionally, a keyboard may report the phantom condition when an invalid or unrecognizable combination of keys is pressed
- [ ] Synchronization between LED states and CAPS LOCK, NUM LOCK, SCROLL LOCK, COMPOSE, and KANA events is maintained by the host and NOT the keyboard. If using the keyboard descriptor in Appendix B, LED states are set by sending a 5-bit absolute report to the keyboard via a Set_Report(Output) request
- [ ] Boot Keyboards must support the boot protocol and the Set_Protocol request. Boot Keyboards may support an alternative protocol (specified in the Report descriptor) for use in USB-aware operating environments.